### PR TITLE
Run Dependabot workflow on `pull_request_target`

### DIFF
--- a/.github/workflows/dependabot_pr_to_linear_issue.yml
+++ b/.github/workflows/dependabot_pr_to_linear_issue.yml
@@ -24,11 +24,8 @@ jobs:
   dependabot-pr-to-linear-issue:
     name: "Dependabot PR to Linear issue"
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.actor == inputs.actor
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened' && github.actor == inputs.actor
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Create issue
         uses: whereby/github-actions/.github/actions/create-linear-issue@1.0.0
         with:


### PR DESCRIPTION
### Description
In order to access secrets, Dependabot workflows should NOT use the `pull_request` event but rather `pull_request_target`. The consuming workflows will also have to be updated to only trigger on this event.

https://github.com/dependabot/dependabot-core/issues/3253

